### PR TITLE
config/production: Set API path relative to the domain of the frontend

### DIFF
--- a/src/config/production.js
+++ b/src/config/production.js
@@ -3,7 +3,7 @@ const config = {
   googleAnalyticsID: 'UA-62791775-3',
   enableGoogleAnalytics: true,
   enableSentry: true,
-  APIBasePath: 'TBD',
+  APIBasePath: '/api',
 };
 
 export default config;


### PR DESCRIPTION
I honestly haven't tested this, but in my experience with web development it should work. Please, test it before merging.

Fixes https://github.com/etcaterva/eas-frontend/issues/17