### PR TITLE
Use the slim version of the base Docker image

### DIFF
--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -1,5 +1,5 @@
 # build environment
-FROM node:dubnium
+FROM node:dubnium-slim
 
 RUN mkdir /usr/src/app
 RUN mkdir -p /var/log/eas3/


### PR DESCRIPTION
It should just work, but I haven't tested it :P

This will save us around 300 MB of space in the docker image.