### PR TITLE
logging: Allow numbering the logs

### DIFF
--- a/src/logging.js
+++ b/src/logging.js
@@ -5,11 +5,12 @@ import * as fs from 'fs';
 import { NullTransport } from 'winston-null';
 import config from './config/config';
 
-const { LOGS_PATH, MAX_FILES } = process.env;
+const { LOGS_PATH, LOGS_SUFFIX, MAX_FILES } = process.env;
 const DEFAULT_MAX_FILES = 5;
 const MAX_SIZE_MORGAN = '10M'; // 10 MB
 const MAX_SIZE_WINSTON = 10485760;
 const maxFiles = MAX_FILES || DEFAULT_MAX_FILES;
+const logsSuffix = LOGS_SUFFIX ? `_${LOGS_SUFFIX}.log` : '.log';
 
 const setupDefaultLogsPath = () => {
   const logsDirectory = path.join('.', 'logs');
@@ -30,12 +31,12 @@ const getFileTransports = () => {
   };
   return [
     new winston.transports.File({
-      filename: path.join(logsPath, 'error.log'),
+      filename: path.join(logsPath, `error${logsSuffix}`),
       level: 'error',
       ...baseRatationOptions,
     }),
     new winston.transports.File({
-      filename: path.join(logsPath, 'combined.log'),
+      filename: path.join(logsPath, `combined${logsSuffix}`),
       ...baseRatationOptions,
     }),
   ];
@@ -70,7 +71,7 @@ export const initWinstonLogging = ({ isServer }) => {
 };
 
 export const getMorganStream = () =>
-  rfs('access.log', {
+  rfs(`access${logsSuffix}`, {
     maxFiles,
     size: MAX_SIZE_MORGAN,
     path: getLogsPath(),

--- a/src/logging.js
+++ b/src/logging.js
@@ -24,7 +24,7 @@ const getLogsPath = () => LOGS_PATH || setupDefaultLogsPath();
 
 const getFileTransports = () => {
   const logsPath = getLogsPath();
-  const baseRatationOptions = {
+  const baseRotationOptions = {
     maxsize: MAX_SIZE_WINSTON,
     tailable: true,
     maxFiles,
@@ -33,11 +33,11 @@ const getFileTransports = () => {
     new winston.transports.File({
       filename: path.join(logsPath, `error${logsSuffix}`),
       level: 'error',
-      ...baseRatationOptions,
+      ...baseRotationOptions,
     }),
     new winston.transports.File({
       filename: path.join(logsPath, `combined${logsSuffix}`),
-      ...baseRatationOptions,
+      ...baseRotationOptions,
     }),
   ];
 };


### PR DESCRIPTION
This way we can make different replicas write to different log files.

The alternative is to just send error messages to stderr/stdout, which would also be acceptable from the logging point of view, to send them to kibana.