### PR TITLE
Use same args on docker push

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -110,6 +110,7 @@ jobs:
           build-args: |
             commit_sha=${{ github.sha }}
             app_env=${{ needs.build-docker.outputs.app_env }}
+            sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 


### PR DESCRIPTION
Yes.. docker-push step is in reality a docker-build-and-push step, that reuses the previous generated cache. I'm still thinking about how to unify these to avoid errors like this one.